### PR TITLE
Remove generate_complete_backup_solution and simplify generate_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ This MCP server provides an AI-friendly interface to generate Terraform configur
 - Organizational units
 - User management
 - Backup compliance report configurations
-- Configuration validation
 
 ## Features
 
@@ -28,10 +27,8 @@ This MCP server provides an AI-friendly interface to generate Terraform configur
 5. **generate_organizational_unit** - Build hierarchical organizational structures
 6. **generate_policy_rule** - Apply policies to resources through rules
 7. **generate_user_assignment** - Manage user access and permissions
-8. **generate_complete_backup_solution** - Generate comprehensive backup configurations
-9. **generate_report_configuration** - Create compliance report configurations
-10. **validate_terraform_config** - Validate configurations for best practices
-11. **get_example_scenarios** - Access common use case examples
+8. **generate_report_configuration** - Create compliance report configurations
+9. **get_example_scenarios** - Access common use case examples
 
 ## Installation
 

--- a/complete_backup_solution.tf
+++ b/complete_backup_solution.tf
@@ -1,4 +1,3 @@
-# Providers
 terraform {
   required_providers {
     clumio = {
@@ -34,7 +33,6 @@ variable "aws_region" {
   default     = "us-west-2"
 }
 
-# AWS Account Connections
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
@@ -64,8 +62,6 @@ module "clumio_aws_resources" {
   is_dynamodb_enabled   = true
 }
 
-
-# Policies
 resource "clumio_policy" "unified_policy" {
   name              = "Unified Policy"
   activation_status = "activated"
@@ -166,8 +162,6 @@ resource "clumio_policy" "unified_policy" {
   }
 }
 
-
-# Protection Groups
 resource "clumio_protection_group" "s3_protection_group" {
   name           = "S3 Protection Group"
   description    = "Protection Group for S3 buckets tagged with backup:true"
@@ -192,7 +186,6 @@ resource "clumio_policy_assignment" "s3_protection_group_assignment" {
   policy_id   = clumio_policy.unified_policy.id
 }
 
-# Policy Rules
 resource "clumio_policy_rule" "unified_protection_rule" {
   policy_id           = clumio_policy.unified_policy.id
   name                = "Unified Protection Rule"
@@ -217,4 +210,3 @@ resource "clumio_policy_rule" "unified_protection_rule" {
     }
   )
 }
-

--- a/example_prompts.md
+++ b/example_prompts.md
@@ -25,7 +25,7 @@ Generate a Clumio protection policy for critical EBS volumes with:
 
 ### Tiered Protection Policies
 ```
-Generate three protection policies for different data tiers:
+Generate three protection policies for different SLAs:
 1. Critical: 1-hour RPO, 90-day retention
 2. Standard: 24-hour RPO, 30-day retention  
 3. Archive: Weekly backups, 1-year retention

--- a/src/clumio_terraform_mcp/app.py
+++ b/src/clumio_terraform_mcp/app.py
@@ -1,14 +1,6 @@
 from fastmcp import FastMCP
-from typing import Any, Final
-from clumio_terraform_mcp import models, utils
-
-DEFAULT_STORAGE_CLASSES: Final = [
-    "S3 Standard", 
-    "S3 Standard-IA", 
-    "S3 Intelligent-Tiering", 
-    "S3 One Zone-IA", 
-    "S3 Reduced Redundancy"
-]
+from typing import Any
+from clumio_terraform_mcp import models, utils, constants
 
 # Initialize MCP server
 mcp = FastMCP("Clumio Terraform Provider MCP Server")
@@ -16,28 +8,10 @@ mcp = FastMCP("Clumio Terraform Provider MCP Server")
 # MCP Tools
 @mcp.tool
 def generate_providers(
-    clumio_accounts:list[models.ClumioAccount], 
+    clumio_accounts: list[models.ClumioAccount], 
     aws_accounts: list[models.AWSAccount]
 ) -> str:
-    """
-    Generate Terraform configuration for Provider blocks of Clumio and AWS.
-
-    Args:
-        clumio_accounts: List of Clumio accounts to generate provider configurations for. Each account may include:
-            alias: The alias for the Clumio provider.
-            ou_name: The name of the organizational unit resource for the Clumio account. If not specified, consider using the default organizational unit.
-        aws_accounts: List of AWS accounts to generate provider configurations for. Each account may include:
-            alias: The alias for the AWS provider.
-            region: The AWS region for the account.
-            profile: The pre-configured AWS profile to use for authentication.
-            assume_role: The assume role configuration for the AWS provider.
-                role_arn: The ARN of the role to assume.
-                session_name: The name of the session to create.
-                external_id: An optional external ID to include in the assume role request.
-
-    Returns:
-        Terraform configuration as string.
-    """
+    """Generate Terraform configuration for Provider blocks of Clumio and AWS."""
     return utils.render_tf_template(
         'provider.tf.j2', clumio_accounts=clumio_accounts, aws_accounts=aws_accounts
     ).strip()
@@ -52,20 +26,16 @@ def generate_aws_connection(
     wait_for_data_plane_resources: bool = False,
     wait_for_ingestion: bool = False
 ) -> str:
-    """
-    Generate Terraform configuration for Clumio AWS connection.
+    """Generate Terraform configuration for Clumio AWS connection.
     
     Args:
-        clumio_provider_alias: Alias name for Clumio provider
         connection_name: Name for the connection resource
         description: Description of the AWS account connection
         services: Dictionary of services to enable (e.g., ebs, rds, s3, dynamodb)
+        clumio_provider_alias: Alias name for Clumio provider
         aws_provider_alias: Alias name for AWS provider
         wait_for_data_plane_resources: Flag to indicate wait for data plane resources to be created
         wait_for_ingestion: Flag to indicate wait for ingestion to complete
-
-    Returns:
-        Terraform configuration as string
     """
     return utils.render_tf_template(
         'aws_connection.tf.j2',
@@ -78,8 +48,6 @@ def generate_aws_connection(
         wait_for_ingestion=wait_for_ingestion,
     ).strip()
 
-    
-
 @mcp.tool
 def generate_policy(
     policy_name: str,
@@ -87,33 +55,13 @@ def generate_policy(
     operations: list[models.Operation],
     clumio_provider_alias: str | None = None,
 ) -> str:
-    """
-    Generate a Clumio policy for backup configuration.
+    """Generate a Clumio policy for backup configuration.
     
     Args:
-        clumio_provider_alias: Alias name for Clumio provider
         policy_name: Resource name for the policy
         display_name: Human-readable name
         operations: List of operation types and settings for policy
-            type: The type of operation to be performed. Depending on the type selected, advanced_settings may also be required. Supported types include:
-                (aws_ebs_volume_backup, aws_ebs_volume_snapshot, aws_ec2_instance_backup, aws_ec2_instance_snapshot, aws_rds_resource_aws_snapshot, aws_rds_resource_rolling_backup, aws_rds_resource_granular_backup, aws_dynamodb_table_backup, aws_dynamodb_table_snapshot, aws_dynamodb_table_pitr, protection_group_backup)
-            action_setting: Determines whether the policy should take action now or during the specified backup window (immediate, window)
-            slas: The service level agreement (SLA) for the policy
-                slas.retention_duration: The time unit of retention duration for the policy
-                slas.rpo_frequency: The time unit of recovery point objective (RPO) frequency for the policy
-            advanced_settings: Additional settings for the policy
-                advanced_settings.aws_ebs_volume_backup: Backup tier configuration for EBS volume backup
-                advanced_settings.aws_ec2_instance_backup: Backup tier configuration for EC2 instance backup
-                advanced_settings.aws_rds_config_sync: Sync configuration for RDS PITR backup
-                advanced_settings.aws_rds_granular_backup: Backup tier configuration for RDS backup
-                advanced_settings.protection_group_backup: Backup tier configuration for S3 protection group backup
-                advanced_settings.protection_group_continuous_backup: Event bridge notification setting for S3 continuous backup
-            backup_aws_region: The region in which this backup is stored. This might be used for cross-region backup. Possible values are AWS region string, for example: us-east-1, us-west-2. If no value is provided, it defaults to in-region
-            backup_window_tz: The start and end times for the customized backup window that reflects the user-defined timezone
-            timezone: The time zone for the policy, in IANA format. This might be set up when backup window exists
-    
-    Returns:
-        Terraform configuration for policy
+        clumio_provider_alias: Alias name for Clumio provider
     """
     return utils.render_tf_template(
         'policy.tf.j2',
@@ -130,14 +78,12 @@ def generate_protection_group(
     policy_name: str,
     description: str,
     bucket_rule: dict[str, Any],
-    storage_classes: list[str] = DEFAULT_STORAGE_CLASSES,
+    storage_classes: list[str] = constants.DEFAULT_STORAGE_CLASSES,
     clumio_provider_alias: str | None = None,
 ) -> str:
-    """
-    Generate a protection group for organizing resources.
+    """Generate a protection group for organizing resources.
     
     Args:
-        clumio_provider_alias: Alias name for Clumio provider
         group_name: Resource name for the group
         display_name: Human-readable name
         policy_name: Reference to the policy resource
@@ -151,9 +97,7 @@ def generate_protection_group(
             - aws_region: Denotes the AWS region to conditionalize on
                 - rule condition: $eq, $in
         storage_classes: List of storage classes to include
-    
-    Returns:
-        Terraform configuration for protection group
+        clumio_provider_alias: Alias name for Clumio provider
     """
     return utils.render_tf_template(
         'protection_group.tf.j2',
@@ -174,19 +118,16 @@ def generate_organizational_unit(
     parent_name: str | None = None,
     clumio_provider_alias: str | None = None,
 ) -> str:
-    """
-    Generate an organizational unit for hierarchical management. Ensure that the provider for OU is set correctly.
-    The provider configuring parent OU should be used to create child OUs.
+    """Generate an organizational unit for hierarchical management.
+
+    Ensure that the provider for OU is set correctly. The provider configuring parent OU should be used to create child OUs.
 
     Args:
-        clumio_provider_alias: Alias name for Clumio provider
         ou_name: Resource name for the OU
         display_name: Human-readable name
         description: Description of the organizational unit
         parent_name: Reference to parent OU (If not provided, defaults to root level)
-
-    Returns:
-        Terraform configuration for organizational unit
+        clumio_provider_alias: Alias name for Clumio provider
     """
     return utils.render_tf_template(
         'organizational_unit.tf.j2',
@@ -206,11 +147,9 @@ def generate_policy_rule(
     before_rule_name: str | None = None,
     clumio_provider_alias: str | None = None,
 ) -> str:
-    """
-    Generate a policy rule to apply protection policies to resources.
+    """Generate a policy rule to apply protection policies to resources.
     
     Args:
-        clumio_provider_alias: Alias name for Clumio provider. Note that policy rules can be created, edited or deleted only by global admin or immediate child OU admins. Which means it doesn't allow providers that configured with grandchild OUs
         rule_name: Resource name for the rule
         display_name: Human-readable name
         policy_name: Reference to the policy resource
@@ -226,9 +165,7 @@ def generate_policy_rule(
             - aws_region: Denotes the AWS region to conditionalize on
                 - rule condition: $eq, $in
         before_rule_name: Reference to the rule which should run before this one
-
-    Returns:
-        Terraform configuration for policy rule
+        clumio_provider_alias: Alias name for Clumio provider. Note that policy rules can be created, edited or deleted only by global admin or immediate child OU admins. Which means it doesn't allow providers that configured with grandchild OUs
     """
     return utils.render_tf_template(
         'policy_rule.tf.j2',
@@ -248,8 +185,7 @@ def generate_user_assignment(
     access_control_configuration: list[models.AccessControlConfiguration],
     clumio_provider_alias: str | None = None,
 ) -> str:
-    """
-    Generate user assignment configuration.
+    """Generate user assignment configuration.
     
     Args:
         clumio_provider_alias: Alias name for Clumio provider
@@ -257,11 +193,6 @@ def generate_user_assignment(
         email: User's email address
         full_name: User's full name
         access_control_configuration: List of access control configurations
-            role_name: Role type (Super Admin, Organizational Unit Admin, Helpdesk Admin)
-            organizational_units: List of OU IDs to assign user to
-    
-    Returns:
-        Terraform configuration for user assignment
     """
     return utils.render_tf_template(
         'user.tf.j2',
@@ -273,94 +204,6 @@ def generate_user_assignment(
     ).strip()
 
 @mcp.tool
-def generate_complete_backup_solution(config: dict[str, Any]) -> str:
-    """
-    Generate a complete Terraform configuration for Clumio backup solution.
-    
-    Args:
-        config: Complete configuration including:
-            - clumio_accounts: List of Clumio accounts to configure
-            - aws_accounts: List of AWS accounts where resources are located
-            - organizational_units: List of organizational units in Clumio
-            - aws_connections: List of AWS connections in Clumio
-            - policies: Backup policies by operation type
-            - protection_groups: Protection groups for S3 Policy
-            - policy_rules: Policy rules to resource mappings except for S3
-            - users: User access configuration
-    
-    Returns:
-        Complete Terraform configuration file
-    """
-    terraform_configs = []
-    
-    # Header and providers
-    terraform_configs.append("# Providers")
-    provider_config = utils.render_tf_template(
-        'provider.tf.j2', 
-        clumio_accounts=config.get('clumio_accounts', []),
-        aws_accounts=config.get('aws_accounts', [])
-    ).strip()
-    terraform_configs.append(provider_config)
-
-    # Generate organizational units
-    if 'organizational_units' in config:
-        terraform_configs.append("\n# Organizational Units")
-        for ou in config['organizational_units']:
-            ou_config = utils.render_tf_template('organizational_unit.tf.j2', **ou)
-            terraform_configs.append(ou_config)
-            terraform_configs.append("")
-
-    # Generate AWS connections
-    if 'aws_connections' in config:
-        terraform_configs.append("\n# AWS Account Connections")
-        for connection in config['aws_connections']:
-            conn_config = utils.render_tf_template('aws_connection.tf.j2', **connection).strip()
-            terraform_configs.append(conn_config)
-            terraform_configs.append("")
-    
-    # Generate policies
-    if 'policies' in config:
-        terraform_configs.append("\n# Policies")
-        for policy in config['policies']:
-            policy['operations'] = [models.Operation(**op) for op in policy['operations']]
-            policy_config = utils.render_tf_template('policy.tf.j2', **policy).strip()
-            terraform_configs.append(policy_config)
-            terraform_configs.append("")
-
-    # Generate protection groups
-    if 'protection_groups' in config:
-        terraform_configs.append("\n# Protection Groups")
-        for group in config['protection_groups']:
-            group['storage_classes'] = group.get('storage_classes', DEFAULT_STORAGE_CLASSES)
-            group_config = utils.render_tf_template(
-                'protection_group.tf.j2', **group
-            ).strip()
-            terraform_configs.append(group_config)
-    
-    # Generate policy rules
-    if 'policy_rules' in config:
-        terraform_configs.append("\n# Policy Rules")
-        for policy_rule in config['policy_rules']:
-            rule_config = utils.render_tf_template(
-                'policy_rule.tf.j2', **policy_rule
-            ).strip()
-            terraform_configs.append(rule_config)
-            terraform_configs.append("")
-    
-    # Generate user assignments
-    if 'users' in config:
-        terraform_configs.append("\n# User Assignments")
-        for user in config['users']:
-            user_config = utils.render_tf_template(
-                'user.tf.j2', **user
-            ).strip()
-            terraform_configs.append(user_config)
-    
-    terraform_configs.append("")  # Final newline
-    
-    return '\n'.join(terraform_configs)
-
-@mcp.tool
 def generate_report_configuration(
     config_name: str,
     config_display_name: str,
@@ -370,8 +213,7 @@ def generate_report_configuration(
     schedule: models.Schedule,
     clumio_provider_alias: str | None = None,
 ) -> str:
-    """
-    Generate compliance report configuration.
+    """Generate compliance report configuration.
     
     Args:
         clumio_provider_alias: Alias name for Clumio provider
@@ -379,34 +221,8 @@ def generate_report_configuration(
         config_display_name: User-friendly display name for the report
         email_list: List of email addresses to notify the report run
         controls: Compliance controls to evaluate policy or assets for compliance
-            asset_backup: The control evaluating whether assets have at least one backup within each window of the specified look back period, with retention meeting the minimum required duration
-                look_back_period: The duration prior to the compliance evaluation point to look back
-                minimum_retention_duration: The minimum required retention duration for a backup to be considered compliant
-                window_size: The size of each evaluation window within the look back period in which at least one compliant backup must exist
-            asset_protection: The control evaluating if all assets are protected with a policy or not
-                should_ignore_deactivated_policy: Treat deactivated policies as compliant if true
-            policy: The control evaluating if policies have a minimum backup retention and frequency
-                minimum_retention_duration: The minimum retention duration for policy control
-                minimum_rpo_duration: The minimum RPO duration for policy control
         filters: Compliance filters to apply
-            asset: The filter for asset. This will be applied to asset backup and asset protection controls
-                groups: The asset groups to be filtered
-                tag_op_mode: The tag filter operation to be applied to the given tags. This is supported for AWS assets only (and, or, equal)
-                tags: The asset tags to be filtered. This is supported for AWS assets only
-            common: The filter for common controls. This will be applied to all controls
-                asset_types: The asset types to be included in the report. This can include:
-                    (aws_ec2_instance, aws_ebs_volume, aws_rds, aws_s3_bucket, aws_dynamodb_table)
-                data_sources: The data sources to be included in the report (e.g. aws)
-                organizational_units: The UUID of organizational units to be included in the report
         schedule: Schedule for the report
-            day_of_month: Day of the month to run the report. This is required for the 'monthly' report frequency (1-28, -1 for last day)
-            day_of_week: Day of the week to run the report. This is required for the 'weekly' report frequency ('monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday')
-            frequency: Frequency of the report ('daily', 'weekly', 'monthly')
-            start_time: Start time for the report generation
-            timezone: Timezone for the report schedule (e.g., "America/New_York")
-
-    Returns:
-        Terraform configuration for the report
     """
     return utils.render_tf_template(
         'report_configuration.tf.j2',
@@ -419,63 +235,10 @@ def generate_report_configuration(
         schedule=schedule
     ).strip()
 
-@mcp.tool
-def validate_terraform_config(config_content: str) -> dict[str, Any]:
-    """
-    Validate Terraform configuration syntax and best practices.
-    
-    Args:
-        config_content: Terraform configuration to validate
-    
-    Returns:
-        Validation results with warnings and recommendations
-    """
-    validation_results = {
-        "is_valid": True,
-        "errors": [],
-        "warnings": [],
-        "recommendations": []
-    }
-    
-    # Check for required provider configuration
-    if "provider \"clumio\"" not in config_content:
-        validation_results["errors"].append("Missing Clumio provider configuration")
-        validation_results["is_valid"] = False
-    
-    if "provider \"aws\"" not in config_content and "aws" in config_content.lower():
-        validation_results["warnings"].append("AWS provider may be required but not configured")
-    
-    # Check for sensitive variable handling
-    if "clumio_api_token" in config_content and "sensitive = true" not in config_content:
-        validation_results["warnings"].append("API token should be marked as sensitive")
-    
-    # Check for hardcoded values
-    if "clumio_api_token =" in config_content and "var." not in config_content:
-        validation_results["errors"].append("API token appears to be hardcoded - use variables instead")
-        validation_results["is_valid"] = False
-    
-    # Best practice recommendations
-    if "terraform {" in config_content:
-        if "required_version" not in config_content:
-            validation_results["recommendations"].append("Consider adding required_version constraint")
-    
-    if "backup_window" in config_content:
-        validation_results["recommendations"].append("Ensure backup windows don't overlap with peak usage times")
-    
-    if "retention" in config_content:
-        validation_results["recommendations"].append("Review retention policies for compliance requirements")
-    
-    return validation_results
-
 # Example usage scenarios
 @mcp.tool
 def get_example_scenarios() -> dict[str, Any]:
-    """
-    Get example scenarios for using the Clumio Terraform MCP server.
-    
-    Returns:
-        Dictionary of example scenarios with descriptions and sample configurations
-    """
+    """Get example scenarios for using the Clumio Terraform MCP server."""
     return {
         "scenarios": [
             {

--- a/src/clumio_terraform_mcp/constants.py
+++ b/src/clumio_terraform_mcp/constants.py
@@ -1,0 +1,9 @@
+from typing import Final
+
+DEFAULT_STORAGE_CLASSES: Final = [
+    "S3 Standard", 
+    "S3 Standard-IA", 
+    "S3 Intelligent-Tiering", 
+    "S3 One Zone-IA", 
+    "S3 Reduced Redundancy"
+]

--- a/src/clumio_terraform_mcp/templates/policy.tf.j2
+++ b/src/clumio_terraform_mcp/templates/policy.tf.j2
@@ -7,7 +7,7 @@ resource "clumio_policy" "{{ policy_name }}" {
   
   {%- for operation in operations %}
   operations {
-    action_setting = "{{ operation.action_setting }}"
+    action_setting = "{{ 'window' if operation.backup_window_tz else 'immediate' }}"
     type           = "{{ operation.type }}"
     {%- for sla in operation.slas %}
     slas {
@@ -21,10 +21,10 @@ resource "clumio_policy" "{{ policy_name }}" {
       }
     }
     {%- endfor %}
-    {%- if operation.advanced_settings %}
+    {%- set adv_setting = operation.generate_advanced_setting() %}
+    {%- if adv_setting %}
     advanced_settings {
-      {%- set adv_settings = operation.advanced_settings.generate_advanced_settings() %}
-      {%- for setting_type, setting_values in adv_settings.items() %}
+      {%- for setting_type, setting_values in adv_setting.items() %}
       {{ setting_type }} {
         {%- for key, value in setting_values.items() %}
         {%- if value is string %}

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -70,12 +70,7 @@ async def test_generate_policy_tool(mcp_server):
                         "unit": "days",
                         "value": 1
                     }
-                }],
-                "advanced_settings": {
-                    "aws_ebs_volume_backup": {
-                        "backup_tier": "standard"
-                    }
-                }
+                }]
             }]
         })
         assert isinstance(result.data, str)
@@ -141,102 +136,3 @@ async def test_generate_user_assignment_tool(mcp_server):
         })
         assert isinstance(result.data, str)
         assert "resource" in result.data
-
-@pytest.mark.asyncio
-async def test_generate_complete_backup_solution_tool(mcp_server):
-    config = {
-        'clumio_accounts': [
-            {'alias': 'test'}
-        ],
-        'aws_accounts': [
-            {'alias': 'prod', 'region': 'us-east-1', 'profile': 'prod'},
-            {'alias': 'dev', 'assume_role': {'role_arn': 'arn:aws:iam::123456789012:role/dev-role'}},
-        ],
-        'aws_connections': [
-            {
-                'clumio_provider_alias': 'test',
-                'connection_name': 'prod', 
-                'description': 'desc', 
-                'services': {'ebs': True, 'rds': True, 's3': True, 'dynamodb': True}, 
-                'aws_provider_alias': 'prod',
-                'wait_for_data_plane_resources': True,
-                'wait_for_ingestion': True,
-            },
-            {
-                'clumio_provider_alias': 'test',
-                'connection_name': 'dev',
-                'description': 'desc',
-                'services': {'ebs': True, 'rds': True, 's3': False, 'dynamodb': False},
-                'aws_provider_alias': 'dev',
-                'wait_for_data_plane_resources': False,
-                'wait_for_ingestion': False
-            }
-        ],
-        'organizational_units': [
-            {'ou_name': 'engineering', 'display_name': 'Engineering', 'description': 'desc'}
-        ],
-        'policies': [
-            {
-                'clumio_provider_alias': 'test',
-                'policy_name': 'policy', 
-                'display_name': 'Policy', 
-                'operations': [{
-                    'type': 'aws_ebs_volume_backup',
-                    'action_setting': 'immediate',
-                    'slas': [{
-                        'retention_duration': {
-                            'unit': 'days',
-                            'value': 7
-                        },
-                        'rpo_frequency': {
-                            'unit': 'days',
-                            'value': 1
-                        }
-                    }],
-                    'advanced_settings': {
-                        'aws_ebs_volume_backup': {
-                            'backup_tier': 'standard'
-                        }
-                    }
-                }]
-            }
-        ],
-        'protection_groups': [
-            {
-                'clumio_provider_alias': 'test', 
-                'group_name': 'group', 
-                'display_name': 'Group', 
-                'policy_name': 'policy', 
-                'description': 'desc', 
-                'bucket_rule': {'aws_tag': {'$eq': {'key': 'k', 'value': 'v'}}},
-                'storage_classes': ['S3 Standard', 'S3 Standard-IA']
-            }
-        ],
-        'policy_rules': [
-            {
-                'clumio_provider_alias': 'test', 
-                'rule_name': 'rule', 
-                'display_name': 'Rule', 
-                'policy_name': 'policy', 
-                'condition_expression': {'aws_tag': {'$eq': {'key': 'k', 'value': 'v'}}}
-            }
-        ],
-        'users': [
-            {
-                'clumio_provider_alias': 'test',
-                'user_name': 'user', 
-                'email': 'user@example.com', 
-                'full_name': 'User', 
-                'access_control_configuration': [
-                    {
-                        'role_name': 'Super Admin',
-                        'organizational_unit_ids': ['00000000-0000-0000-0000-000000000000']
-                    }
-                ]
-            }
-        ]
-    }
-    async with Client(mcp_server) as client:
-        result = await client.call_tool("generate_complete_backup_solution", {"config": config})
-        assert isinstance(result.data, str)
-        assert "terraform" in result.data

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -40,25 +40,11 @@ class TestClient(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, 'mocked_data')
         self.mock_client.call_tool.assert_called_with('generate_policy_rule', unittest.mock.ANY)
 
-    async def test_demo_complete_solution(self):
-        self.mock_client.call_tool.return_value = self.mock_result
-        with patch('builtins.open', unittest.mock.mock_open()):
-            result = await client.demo_complete_solution(self.mock_client)
-        self.assertEqual(result, 'mocked_data')
-        self.mock_client.call_tool.assert_called_with('generate_complete_backup_solution', unittest.mock.ANY)
-
     async def test_demo_report_configuration(self):
         self.mock_client.call_tool.return_value = self.mock_result
         result = await client.demo_report_configuration(self.mock_client)
         self.assertEqual(result, 'mocked_data')
         self.mock_client.call_tool.assert_called_with('generate_report_configuration', unittest.mock.ANY)
-
-    async def test_demo_validation(self):
-        self.mock_result.data = {'is_valid': True, 'errors': [], 'warnings': [], 'recommendations': []}
-        self.mock_client.call_tool.return_value = self.mock_result
-        result = await client.demo_validation(self.mock_client)
-        self.assertEqual(result, self.mock_result.data)
-        self.mock_client.call_tool.assert_called_with('validate_terraform_config', unittest.mock.ANY)
 
     async def test_demo_example_scenarios(self):
         self.mock_result.data = {'scenarios': [], 'integration_examples': {}}


### PR DESCRIPTION
Summary:
- Remove generate_complete_solution as it could be replaced with other methods.
- Simplify docstrings as LLMs consume data from the Pydantic model description as well.
- Remove `validate_terraform_config` as we have `terraform validate` command.
- Remove `AdvancedSettings` and related models to simplify.
- Remove `action_setting` field from `Operation` and change it to determine based on backup window.

Testing:
- manually tested in local